### PR TITLE
add DHCP lease folders for Ubuntu

### DIFF
--- a/setup/bindir/cloud-set-guest-sshkey.in
+++ b/setup/bindir/cloud-set-guest-sshkey.in
@@ -27,7 +27,7 @@
 user=root
 
 # Add your DHCP lease folders here
-DHCP_FOLDERS="/var/lib/dhclient/* /var/lib/dhcp3/*"
+DHCP_FOLDERS="/var/lib/dhclient/* /var/lib/dhcp3/* /var/lib/dhcp/*"
 keys_received=0
 file_count=0
 


### PR DESCRIPTION
Add "/var/lib/dhcp/*" to the search path for Ubuntu; tested under Ubuntu Precise and Trusty, not yet with newer releases.
